### PR TITLE
Fix segfault when length of ciphertext < crypto_box_sealbytes

### DIFF
--- a/c_src/libsodium_api_crypto_box.c
+++ b/c_src/libsodium_api_crypto_box.c
@@ -1402,6 +1402,7 @@ LS_API_INIT(crypto_box, seal_open)
 	int type;
 	int type_length;
 	unsigned long long clen;
+        size_t sealbytes;
 	size_t publickeybytes;
 	size_t secretkeybytes;
 	ErlDrvSizeT x;
@@ -1413,6 +1414,12 @@ LS_API_INIT(crypto_box, seal_open)
 	}
 
 	clen = (unsigned long long)(type_length);
+
+        sealbytes = crypto_box_sealbytes();
+
+        if (clen < sealbytes) {
+                return -1;
+        }
 
 	skip = *index;
 


### PR DESCRIPTION
Hi there,

I discovered that passing a ciphertext with length less than the return value of crypto_box_sealbytes results in a segfault in the erlang-libsodium driver.  The offending length is calculated on line 1492 of libsodium_api_crypto_box.c:

```
         size_t sealbytes = crypto_box_sealbytes();
         size_t mlen = argv->clen - sealbytes;
```

The calculated value is later passed to sodium_memzero, which results in a segmentation fault, crashing the Erlang VM.  This pull request verifies that the ciphertext is of at least length `crypto_box_sealbytes()`.

Regards,
- Mike